### PR TITLE
FileInfo is not null if file no longer exists.

### DIFF
--- a/NitroNet.ViewEngine/IO/FileSystem.cs
+++ b/NitroNet.ViewEngine/IO/FileSystem.cs
@@ -351,7 +351,7 @@ namespace NitroNet.ViewEngine.IO
                     fileInfo = null;
 			    }
 
-				if (fileInfo == null || !fileInfo.Exists)
+				if (fileInfo == null)
 					return null;
 
 				return new FileInfo(filePath, fileInfo);


### PR DESCRIPTION
FileInfo is not null if file no longer exists. Before this resulted to in a NullReferenceException in the method NotifySubscriptions().

Hallo lieber Fabian
Wie besprochen unsere Änderung.

LG