### PR TITLE
Feature/improve fileinfo cache

### DIFF
--- a/NitroNet.ViewEngine/IO/FileSystem.cs
+++ b/NitroNet.ViewEngine/IO/FileSystem.cs
@@ -44,7 +44,6 @@ namespace NitroNet.ViewEngine.IO
 		private void Initialize()
 		{
             _fileInfo = new HashSet<PathInfo>();
-            _fileInfoCache = new Dictionary<PathInfo, FileInfo>();
             _directoryInfo = new HashSet<PathInfo>();
 
             foreach (var viewPath in _configuration.ViewPaths)


### PR DESCRIPTION
A null reference exception frequently was thrown when developing locally. This was due to the _fileInfoCache dictionary being reset before the new fileInfo was read from disk (which could take 2-3 minutes in large projects)
It is not necessary to reset the cache to an empty dictionary. By removing that line, instead, immediately after reading fileInfo from disk, the existing cache will be overwritten. This reduces waiting time for developers after file system changes.